### PR TITLE
A Fix: Using string functions like `charAt` safely

### DIFF
--- a/src/app/shared/pipes/capitalize.pipe.ts
+++ b/src/app/shared/pipes/capitalize.pipe.ts
@@ -4,10 +4,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class CapitalizePipe implements PipeTransform {
 
   transform(value: any) {
-	  if (value) {
-      	return value.charAt(0).toUpperCase() + value.slice(1);
-	  }
-	  return value;
+    return typeof value === 'string' && value.charAt(0).toUpperCase() + value.slice(1) || value;
   }
-
 }


### PR DESCRIPTION
- Currently, passing an integer to the pipe will cause a thrown exception, so I updated it to check if the value is a string.
- Optimizing the code by removing the unneeded `if` condition and falling back to the value passed itself.